### PR TITLE
Add force flag to tag creation

### DIFF
--- a/release.py
+++ b/release.py
@@ -98,9 +98,9 @@ bash_cmd(['git', 'commit', '-m', commit_message])
 bash_cmd(['git','push'])
 
 # create a release tag from the latest version
-bash_cmd(['git', 'tag', 'release/v'+ core_vers_string_now ])
+bash_cmd(['git', 'tag', '-f', 'release/v'+ core_vers_string_now ])
 # push tags
-bash_cmd(['git', 'push', '--tags'])
+bash_cmd(['git', 'push', '--force', '--tags'])
 
 ## update master branch from dev branch
 bash_cmd(['git', 'checkout', 'master'])


### PR DESCRIPTION
This updates the reference if the tag was already created rather than keeping the ref behind and generating packages with the wrong version string