### PR TITLE
Prevent duplicated commits in master

### DIFF
--- a/release.py
+++ b/release.py
@@ -105,10 +105,11 @@ bash_cmd(['git', 'push', '--tags'])
 ## update master branch from dev branch
 bash_cmd(['git', 'checkout', 'master'])
 bash_cmd(['git', 'pull'])
-bash_cmd(['git', 'rebase', 'release/v' + core_vers_string_now])
-bash_cmd(['git', 'push'])
-bash_cmd(['git', 'merge', 'release/v' + core_vers_string_now])
-bash_cmd(['git', 'pull'])
+bash_cmd([
+    'git', 'merge', '--ff', '-m',
+    'Update to v' + core_vers_string_now,
+    'release/v' + core_vers_string_now
+])
 bash_cmd(['git', 'push'])
 
 


### PR DESCRIPTION
Using git merge --ff will give no extra commits if the history is the same, but will still work as expected, bringing in one set of commits with an extra merge commit, if the histories are different